### PR TITLE
feat: Add job applications retrieval for employers with filtering and validation

### DIFF
--- a/app/Http/Controllers/Api/ApplicationController.php
+++ b/app/Http/Controllers/Api/ApplicationController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\Api;
 
+use App\Enums\ApplicationStatus;
 use App\Enums\UserRole;
 use App\Http\Requests\Apply\StoreApplicationRequest;
 use App\Http\Resources\ApplicationResource;
@@ -11,6 +12,7 @@ use App\Services\ApplicationService;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Validation\Rule;
 
 class ApplicationController extends BaseApiController
 {
@@ -47,6 +49,39 @@ class ApplicationController extends BaseApiController
                 'from' => $applications->firstItem(),
                 'to' => $applications->lastItem(),
             ]);
+    }
+
+    /**
+     * List all applications for a specific job.
+     * GET /jobs/{job}/applications
+     */
+    public function jobApplications(Request $request, Job $job): JsonResponse
+    {
+        if (Auth::user()->id !== $job->company->user_id) {
+            return $this->forbidden('You do not own this job posting.');
+        }
+
+        $request->validate([
+            'status' => ['sometimes', Rule::in(ApplicationStatus::values())],
+        ]);
+
+        $applications = $this->applicationService
+            ->getJobApplicationsQuery($job, $request->query('status'))
+            ->paginate(15);
+
+        return $this->success(
+            ApplicationResource::collection($applications),
+            'Applications retrieved successfully',
+            200,
+            [
+                'current_page' => $applications->currentPage(),
+                'last_page' => $applications->lastPage(),
+                'per_page' => $applications->perPage(),
+                'total' => $applications->total(),
+                'from' => $applications->firstItem(),
+                'to' => $applications->lastItem(),
+            ]
+        );
     }
 
     /**

--- a/app/Http/Resources/ApplicationResource.php
+++ b/app/Http/Resources/ApplicationResource.php
@@ -33,6 +33,8 @@ class ApplicationResource extends JsonResource
                 'id' => $this->user->id,
                 'name' => $this->user->name,
                 'email' => $this->user->email,
+                'phone' => $this->user->phone,
+                'linkedin_url' => $this->user->linkedin_url,
             ],
 
         ];

--- a/app/Services/ApplicationService.php
+++ b/app/Services/ApplicationService.php
@@ -9,6 +9,7 @@ use App\Http\Requests\Apply\StoreApplicationRequest;
 use App\Models\Application;
 use App\Models\Job;
 use Illuminate\Contracts\Filesystem\Factory as StorageFactory;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Facades\Auth;
 
 class ApplicationService
@@ -42,6 +43,22 @@ class ApplicationService
     public function getAllQuery()
     {
         return Application::with(['job', 'user']);
+    }
+
+    /**
+     * Build a query for applications on a specific job.
+     *
+     * @return Builder<Application>
+     */
+    public function getJobApplicationsQuery(Job $job, ?string $status = null)
+    {
+        $query = $job->applications()->with(['user', 'job.company']);
+
+        if ($status) {
+            $query->where('status', $status);
+        }
+
+        return $query->latest();
     }
 
     /**

--- a/routes/api.php
+++ b/routes/api.php
@@ -23,6 +23,7 @@ Route::middleware('auth:sanctum')->group(function () {
 
     //  Applications
     Route::post('/jobs/{job}/apply', [ApplicationController::class, 'store']);
+    Route::get('/jobs/{job}/applications', [ApplicationController::class, 'jobApplications']);
     Route::get('/applications', [ApplicationController::class, 'index']);
     Route::get('/applications/{application}', [ApplicationController::class, 'show']);
     Route::delete('/applications/{application}', [ApplicationController::class, 'destroy']);

--- a/tests/Feature/ApplicationIndexTest.php
+++ b/tests/Feature/ApplicationIndexTest.php
@@ -302,6 +302,117 @@ it('prevents an employer from withdrawing an application', function () {
 // Note: Admins bypass all policies via Gate::before in AppServiceProvider,
 // so they CAN withdraw applications. This is consistent with the platform design.
 
+// ─────────────────────────────────────────────────────────────
+// GET /jobs/{job}/applications (Employer)
+// ─────────────────────────────────────────────────────────────
+
+it('allows an employer to view applications for their job', function () {
+    $employer = User::factory()->create(['role' => UserRole::EMPLOYER]);
+    $company = Company::factory()->create(['user_id' => $employer->id]);
+    $job = Job::factory()->approved()->create(['company_id' => $company->id]);
+
+    Application::factory()->count(3)->create(['job_id' => $job->id]);
+
+    $response = $this->actingAs($employer, 'sanctum')
+        ->getJson("/api/jobs/{$job->id}/applications");
+
+    $response->assertOk()
+        ->assertJsonPath('success', true)
+        ->assertJsonPath('message', 'Applications retrieved successfully')
+        ->assertJsonCount(3, 'data')
+        ->assertJsonPath('meta.total', 3);
+});
+
+it('allows an employer to filter applications by status', function () {
+    $employer = User::factory()->create(['role' => UserRole::EMPLOYER]);
+    $company = Company::factory()->create(['user_id' => $employer->id]);
+    $job = Job::factory()->approved()->create(['company_id' => $company->id]);
+
+    Application::factory()->count(2)->create(['job_id' => $job->id, 'status' => ApplicationStatus::PENDING]);
+    Application::factory()->count(1)->create(['job_id' => $job->id, 'status' => ApplicationStatus::ACCEPTED]);
+    Application::factory()->count(1)->create(['job_id' => $job->id, 'status' => ApplicationStatus::REJECTED]);
+
+    $response = $this->actingAs($employer, 'sanctum')
+        ->getJson("/api/jobs/{$job->id}/applications?status=pending");
+
+    $response->assertOk()
+        ->assertJsonPath('meta.total', 2)
+        ->assertJsonPath('data.0.status', 'pending');
+});
+
+it('includes candidate info and resume url for employer view', function () {
+    $employer = User::factory()->create(['role' => UserRole::EMPLOYER]);
+    $company = Company::factory()->create(['user_id' => $employer->id]);
+    $job = Job::factory()->approved()->create(['company_id' => $company->id]);
+    $candidate = User::factory()->create([
+        'role' => UserRole::CANDIDATE,
+        'phone' => '+1234567890',
+        'linkedin_url' => 'https://linkedin.com/in/candidate',
+    ]);
+    Application::factory()->create(['job_id' => $job->id, 'user_id' => $candidate->id]);
+
+    $response = $this->actingAs($employer, 'sanctum')
+        ->getJson("/api/jobs/{$job->id}/applications");
+
+    $response->assertOk();
+
+    $app = $response->json('data.0');
+    expect($app['user'])->toHaveKey('phone')
+        ->and($app['user']['phone'])->toBe('+1234567890')
+        ->and($app['user'])->toHaveKey('linkedin_url')
+        ->and($app['user']['linkedin_url'])->toBe('https://linkedin.com/in/candidate')
+        ->and($app)->toHaveKey('resume_url')
+        ->and($app['resume_url'])->not->toBeNull();
+});
+
+it('prevents a non-owner employer from viewing job applications', function () {
+    $employerA = User::factory()->create(['role' => UserRole::EMPLOYER]);
+    $employerB = User::factory()->create(['role' => UserRole::EMPLOYER]);
+    $companyB = Company::factory()->create(['user_id' => $employerB->id]);
+    $job = Job::factory()->approved()->create(['company_id' => $companyB->id]);
+
+    Application::factory()->count(2)->create(['job_id' => $job->id]);
+
+    $response = $this->actingAs($employerA, 'sanctum')
+        ->getJson("/api/jobs/{$job->id}/applications");
+
+    $response->assertForbidden()
+        ->assertJsonPath('success', false)
+        ->assertJsonPath('message', 'You do not own this job posting.');
+});
+
+it('prevents a candidate from viewing job applications', function () {
+    $candidate = User::factory()->create(['role' => UserRole::CANDIDATE]);
+    $job = Job::factory()->approved()->create();
+
+    $response = $this->actingAs($candidate, 'sanctum')
+        ->getJson("/api/jobs/{$job->id}/applications");
+
+    $response->assertForbidden()
+        ->assertJsonPath('success', false);
+});
+
+it('rejects unauthenticated job applications requests', function () {
+    $job = Job::factory()->approved()->create();
+
+    $response = $this->getJson("/api/jobs/{$job->id}/applications");
+
+    $response->assertUnauthorized()
+        ->assertJsonPath('success', false);
+});
+
+it('rejects invalid status filter values', function () {
+    $employer = User::factory()->create(['role' => UserRole::EMPLOYER]);
+    $company = Company::factory()->create(['user_id' => $employer->id]);
+    $job = Job::factory()->approved()->create(['company_id' => $company->id]);
+
+    $response = $this->actingAs($employer, 'sanctum')
+        ->getJson("/api/jobs/{$job->id}/applications?status=invalid");
+
+    $response->assertUnprocessable()
+        ->assertJsonValidationErrors(['status']);
+});
+
 it('rejects unauthenticated delete requests', function () {
     $application = Application::factory()->create();
 


### PR DESCRIPTION
This pull request introduces a new API endpoint that allows employers to view and filter applications for their own job postings. It also enhances the application resource with additional candidate information and adds comprehensive tests to ensure correct access control and filtering.

**New API endpoint for job applications:**

* Adds `jobApplications` method to `ApplicationController`, allowing employers to list and filter applications for a specific job, with proper authorization and status filtering.
* Registers the new route `GET /jobs/{job}/applications` in `api.php`.
* Implements the `getJobApplicationsQuery` method in `ApplicationService` to support filtered and paginated queries for job applications.

**Enhancements to application resource:**

* Updates `ApplicationResource` to include candidate's `phone` and `linkedin_url` fields in the API response.

**Comprehensive feature tests:**

* Adds tests for the new endpoint, covering employer access, filtering by status, inclusion of candidate info, access control for non-owners and candidates, unauthenticated requests, and invalid filters.

**Dependency and import updates:**

* Adds relevant imports for new features and validation in `ApplicationController` and `ApplicationService`. [[1]](diffhunk://#diff-aac0460f8cd44b3bdf142c9636ca301b7ee86dcd81bf919048dad9f9d8aa1b86R5) [[2]](diffhunk://#diff-aac0460f8cd44b3bdf142c9636ca301b7ee86dcd81bf919048dad9f9d8aa1b86R15) [[3]](diffhunk://#diff-ebae744592cea6c44da8be19e3cec77b310e8283306ab584b9ae0d5bed76214dR12)


**Closes #21**