### PR TITLE
feat: Add application status update endpoint for employers

### DIFF
--- a/app/Http/Controllers/Api/ApplicationController.php
+++ b/app/Http/Controllers/Api/ApplicationController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\Api;
 use App\Enums\ApplicationStatus;
 use App\Enums\UserRole;
 use App\Http\Requests\Apply\StoreApplicationRequest;
+use App\Http\Requests\UpdateApplicationStatusRequest;
 use App\Http\Resources\ApplicationResource;
 use App\Models\Application;
 use App\Models\Job;
@@ -114,9 +115,16 @@ class ApplicationController extends BaseApiController
     /**
      * Update the specified resource in storage.
      */
-    public function update(Request $request, Application $application): JsonResponse
+    public function updateStatus(UpdateApplicationStatusRequest $request, Application $application): JsonResponse
     {
-        //
+        $this->authorize('updateStatus', $application);
+
+        $updatedApplication = $this->applicationService->updateStatus($request, $application);
+
+        return $this->success(
+            ApplicationResource::make($updatedApplication->load(['job.company', 'user'])),
+            'Application status updated successfully'
+        );
     }
 
     /**

--- a/app/Http/Requests/UpdateApplicationStatusRequest.php
+++ b/app/Http/Requests/UpdateApplicationStatusRequest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Http\Requests;
+
+use App\Enums\ApplicationStatus;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Validation\Rule;
+
+class UpdateApplicationStatusRequest extends BaseApiRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'status' => ['required', 'string', Rule::in([
+                ApplicationStatus::ACCEPTED->value,
+                ApplicationStatus::REJECTED->value,
+            ])],
+            'rejection_reason' => [
+                'nullable',
+                'string',
+                'max:2000',
+                'prohibited_unless:status,'.ApplicationStatus::REJECTED->value,
+            ],
+        ];
+    }
+}

--- a/app/Http/Resources/ApplicationResource.php
+++ b/app/Http/Resources/ApplicationResource.php
@@ -29,6 +29,7 @@ class ApplicationResource extends JsonResource
             'status' => $this->status->value,
             'status_label' => $this->status->label(),
             'created_at' => $this->created_at->toDateTimeString(),
+            'rejection_reason' => $this->rejection_reason,
             'user' => [
                 'id' => $this->user->id,
                 'name' => $this->user->name,

--- a/app/Models/Application.php
+++ b/app/Models/Application.php
@@ -20,6 +20,7 @@ class Application extends Model
         'resume',
         'cover_letter',
         'status',
+        'rejection_reason',
     ];
 
     protected function casts(): array

--- a/app/Policies/ApplicationPolicy.php
+++ b/app/Policies/ApplicationPolicy.php
@@ -40,6 +40,11 @@ class ApplicationPolicy
         return $user->id === $application->user_id;
     }
 
+    public function updateStatus(User $user, Application $application): bool
+    {
+        return $user->id === $application->job->company->user_id;
+    }
+
     /**
      * Determine whether the user can delete the model.
      */

--- a/app/Services/ApplicationService.php
+++ b/app/Services/ApplicationService.php
@@ -6,6 +6,7 @@ use App\Enums\ApplicationStatus;
 use App\Enums\JobStatus;
 use App\Exceptions\ApiException;
 use App\Http\Requests\Apply\StoreApplicationRequest;
+use App\Http\Requests\UpdateApplicationStatusRequest;
 use App\Models\Application;
 use App\Models\Job;
 use Illuminate\Contracts\Filesystem\Factory as StorageFactory;
@@ -38,6 +39,26 @@ class ApplicationService
             'cover_letter' => $request->input('cover_letter'),
             'status' => ApplicationStatus::PENDING,
         ]);
+    }
+
+    public function updateStatus(UpdateApplicationStatusRequest $request, Application $application): Application
+    {
+        if (! $application->status->isPending()) {
+            throw new ApiException('Only pending applications can be updated.', 422);
+        }
+        $application->update([
+            'status' => $request->enum('status', ApplicationStatus::class),
+            'rejection_reason' => $request->status === ApplicationStatus::REJECTED->value
+                ? $request->input('rejection_reason')
+                : null,
+        ]);
+        // TODO: Status history audit log (deferred to post-MVP).
+        // Capture $oldStatus before update, then write to application_status_histories
+        // with from_status, to_status, changed_by (Auth::id()), and reason.
+
+        app(NotificationService::class)->notifyApplicationStatusChanged($application->load('job'));
+
+        return $application;
     }
 
     public function getAllQuery()

--- a/app/Services/NotificationService.php
+++ b/app/Services/NotificationService.php
@@ -14,9 +14,15 @@ class NotificationService
     {
         $statusLabel = ucfirst($application->status->value);
 
+        $message = "Your application for \"{$application->job->title}\" has been {$statusLabel}.";
+
+        if ($application->status->isRejected() && $application->rejection_reason) {
+            $message .= ' Reason: '.$application->rejection_reason;
+        }
+
         $application->user->notifications()->create([
             'type' => 'application_status_changed',
-            'message' => "Your application for \"{$application->job->title}\" has been {$statusLabel}.",
+            'message' => $message,
             'is_read' => false,
         ]);
     }

--- a/database/migrations/2026_05_08_073849_add_rejection_reason_to_applications_table.php
+++ b/database/migrations/2026_05_08_073849_add_rejection_reason_to_applications_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('applications', function (Blueprint $table) {
+            $table->text('rejection_reason')->nullable()->after('status');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('applications', function (Blueprint $table) {
+            $table->dropColumn('rejection_reason');
+        });
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -38,6 +38,7 @@ Route::middleware('auth:sanctum')->group(function () {
     Route::get('/applications', [ApplicationController::class, 'index']);
     Route::get('/applications/{application}', [ApplicationController::class, 'show']);
     Route::delete('/applications/{application}', [ApplicationController::class, 'destroy']);
+    Route::patch('/applications/{application}/status', [ApplicationController::class, 'updateStatus']);
 
     //  Comments
     Route::get('/jobs/{job}/comments', [CommentController::class, 'index']);

--- a/tests/Feature/ApplicationStatusUpdateTest.php
+++ b/tests/Feature/ApplicationStatusUpdateTest.php
@@ -1,0 +1,182 @@
+<?php
+
+use App\Enums\ApplicationStatus;
+use App\Enums\UserRole;
+use App\Models\Application;
+use App\Models\Company;
+use App\Models\Job;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Storage;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    Storage::fake('r2');
+});
+
+function statusUpdateEmployerWithCompany(): User
+{
+    $employer = User::factory()->create(['role' => UserRole::EMPLOYER]);
+    Company::factory()->create(['user_id' => $employer->id]);
+
+    return $employer;
+}
+
+// ── Success Cases ────────────────────────────────────────────────────────────
+
+test('employer can accept a pending application', function () {
+    $employer = statusUpdateEmployerWithCompany();
+    $job = Job::factory()->create(['company_id' => $employer->company->id]);
+    $application = Application::factory()->create(['job_id' => $job->id]);
+
+    $response = $this->actingAs($employer)
+        ->patchJson("/api/applications/{$application->id}/status", [
+            'status' => ApplicationStatus::ACCEPTED->value,
+        ]);
+
+    $response->assertOk()
+        ->assertJsonPath('success', true)
+        ->assertJsonPath('data.status', ApplicationStatus::ACCEPTED->value)
+        ->assertJsonPath('data.rejection_reason', null);
+
+    expect($application->fresh()->status)->toBe(ApplicationStatus::ACCEPTED);
+});
+
+test('employer can reject an application with a reason', function () {
+    $employer = statusUpdateEmployerWithCompany();
+    $job = Job::factory()->create(['company_id' => $employer->company->id]);
+    $application = Application::factory()->create(['job_id' => $job->id]);
+
+    $response = $this->actingAs($employer)
+        ->patchJson("/api/applications/{$application->id}/status", [
+            'status' => ApplicationStatus::REJECTED->value,
+            'rejection_reason' => 'We decided to move forward with another candidate.',
+        ]);
+
+    $response->assertOk()
+        ->assertJsonPath('success', true)
+        ->assertJsonPath('data.status', ApplicationStatus::REJECTED->value)
+        ->assertJsonPath('data.rejection_reason', 'We decided to move forward with another candidate.');
+
+    expect($application->fresh()->status)->toBe(ApplicationStatus::REJECTED);
+});
+
+test('employer can reject an application without a reason', function () {
+    $employer = statusUpdateEmployerWithCompany();
+    $job = Job::factory()->create(['company_id' => $employer->company->id]);
+    $application = Application::factory()->create(['job_id' => $job->id]);
+
+    $response = $this->actingAs($employer)
+        ->patchJson("/api/applications/{$application->id}/status", [
+            'status' => ApplicationStatus::REJECTED->value,
+        ]);
+
+    $response->assertOk()
+        ->assertJsonPath('success', true)
+        ->assertJsonPath('data.rejection_reason', null);
+});
+
+// ── Authorization ────────────────────────────────────────────────────────────
+
+test('candidate cannot update application status', function () {
+    $candidate = User::factory()->create(['role' => UserRole::CANDIDATE]);
+    $application = Application::factory()->create(['user_id' => $candidate->id]);
+
+    $this->actingAs($candidate)
+        ->patchJson("/api/applications/{$application->id}/status", [
+            'status' => ApplicationStatus::ACCEPTED->value,
+        ])
+        ->assertForbidden();
+});
+
+test('employer cannot update application for another employers job', function () {
+    $employer1 = employerWithCompany();
+    $employer2 = employerWithCompany();
+    $job = Job::factory()->create(['company_id' => $employer2->company->id]);
+    $application = Application::factory()->create(['job_id' => $job->id]);
+
+    $this->actingAs($employer1)
+        ->patchJson("/api/applications/{$application->id}/status", [
+            'status' => ApplicationStatus::ACCEPTED->value,
+        ])
+        ->assertForbidden();
+});
+
+// ── Validation ───────────────────────────────────────────────────────────────
+
+test('status must be accepted or rejected', function () {
+    $employer = statusUpdateEmployerWithCompany();
+    $job = Job::factory()->create(['company_id' => $employer->company->id]);
+    $application = Application::factory()->create(['job_id' => $job->id]);
+
+    $this->actingAs($employer)
+        ->patchJson("/api/applications/{$application->id}/status", [
+            'status' => ApplicationStatus::PENDING->value,
+        ])
+        ->assertUnprocessable()
+        ->assertJsonValidationErrors(['status']);
+});
+
+test('rejection reason is prohibited when status is accepted', function () {
+    $employer = statusUpdateEmployerWithCompany();
+    $job = Job::factory()->create(['company_id' => $employer->company->id]);
+    $application = Application::factory()->create(['job_id' => $job->id]);
+
+    $this->actingAs($employer)
+        ->patchJson("/api/applications/{$application->id}/status", [
+            'status' => ApplicationStatus::ACCEPTED->value,
+            'rejection_reason' => 'Some reason',
+        ])
+        ->assertUnprocessable()
+        ->assertJsonValidationErrors(['rejection_reason']);
+});
+
+// ── Business Rules ───────────────────────────────────────────────────────────
+
+test('only pending applications can be updated', function () {
+    $employer = statusUpdateEmployerWithCompany();
+    $job = Job::factory()->create(['company_id' => $employer->company->id]);
+    $application = Application::factory()->accepted()->create(['job_id' => $job->id]);
+
+    $this->actingAs($employer)
+        ->patchJson("/api/applications/{$application->id}/status", [
+            'status' => ApplicationStatus::REJECTED->value,
+        ])
+        ->assertUnprocessable()
+        ->assertJsonPath('message', 'Only pending applications can be updated.');
+});
+
+// ── Notifications ────────────────────────────────────────────────────────────
+
+test('accepting application sends notification to candidate', function () {
+    $employer = statusUpdateEmployerWithCompany();
+    $job = Job::factory()->create(['company_id' => $employer->company->id]);
+    $application = Application::factory()->create(['job_id' => $job->id]);
+
+    $this->actingAs($employer)->patchJson("/api/applications/{$application->id}/status", [
+        'status' => ApplicationStatus::ACCEPTED->value,
+    ]);
+
+    $this->assertDatabaseHas('notifications', [
+        'user_id' => $application->user_id,
+        'type' => 'application_status_changed',
+    ]);
+});
+
+test('rejection notification includes reason when provided', function () {
+    $employer = statusUpdateEmployerWithCompany();
+    $job = Job::factory()->create(['company_id' => $employer->company->id]);
+    $application = Application::factory()->create(['job_id' => $job->id]);
+
+    $this->actingAs($employer)->patchJson("/api/applications/{$application->id}/status", [
+        'status' => ApplicationStatus::REJECTED->value,
+        'rejection_reason' => 'Missing required skills.',
+    ]);
+
+    $this->assertDatabaseHas('notifications', [
+        'user_id' => $application->user_id,
+        'type' => 'application_status_changed',
+        'message' => 'Your application for "'.$job->title.'" has been Rejected. Reason: Missing required skills.',
+    ]);
+});


### PR DESCRIPTION
This pull request introduces a new feature that allows employers to update the status of job applications to either "accepted" or "rejected," with an optional rejection reason. The update includes backend validation, authorization, notification enhancements, and comprehensive tests to ensure correct behavior and permissions.

**Application status update feature:**

* Added a new endpoint (`PATCH /applications/{application}/status`) and controller method (`updateStatus`) to allow employers to update the status of applications, with proper authorization and validation. [[1]](diffhunk://#diff-aac0460f8cd44b3bdf142c9636ca301b7ee86dcd81bf919048dad9f9d8aa1b86L117-R127) [[2]](diffhunk://#diff-0e4323e6a03c91c9c8dc88afef15fdad09636468c0ac3550f497618372788b6dR41) [[3]](diffhunk://#diff-bccd0de3b618b75f5eccd7e527d11cd07d58e53971b2d432007f2a4d7234c12dR43-R47) [[4]](diffhunk://#diff-f3c8fd4424063df93dfaeda6abd50035d45b0f5f2f8efee05bdb02e60a534ca8R1-R39)
* Introduced the `UpdateApplicationStatusRequest` for validating status updates, ensuring only "accepted" or "rejected" values are allowed, and that a rejection reason is only provided for rejections.
* Implemented business logic in `ApplicationService` to handle status updates, enforce that only pending applications can be updated, and trigger notifications.

**Database and model changes:**

* Added a `rejection_reason` column to the `applications` table and updated the `Application` model to support storing and retrieving rejection reasons. [[1]](diffhunk://#diff-dd7aa8b6cbba7fdb9d2e1676d471bb17174d0642bf625971f8c5a3db91190881R1-R28) [[2]](diffhunk://#diff-1eca6e8e29157327525b18f28dcdf07a896ab91ac7dd1dd5756ab3b3a36cd2e9R23)
* Updated `ApplicationResource` to include `rejection_reason` in API responses.

**Notifications:**

* Enhanced notifications to include the rejection reason in the message when an application is rejected with a reason.

**Testing:**

* Added a comprehensive feature test suite (`ApplicationStatusUpdateTest.php`) covering success cases, authorization, validation, business rules, and notification content.

**Closes #22**