### PR TITLE
fix:Remove deprecated employer application status endpoint

### DIFF
--- a/app/Http/Controllers/Api/EmployerAnalyticsController.php
+++ b/app/Http/Controllers/Api/EmployerAnalyticsController.php
@@ -6,11 +6,8 @@ use App\Enums\ApplicationStatus;
 use App\Enums\UserRole;
 use App\Models\Application;
 use App\Models\Job;
-use App\Services\NotificationService;
 use Illuminate\Http\JsonResponse;
-use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
-use Illuminate\Validation\Rule;
 
 class EmployerAnalyticsController extends BaseApiController
 {
@@ -80,36 +77,5 @@ class EmployerAnalyticsController extends BaseApiController
             ->paginate(15);
 
         return $this->paginated($applications, 'Applications retrieved successfully');
-    }
-
-    /**
-     * Accept or reject an application.
-     * PATCH /employer/applications/{application}
-     */
-    public function updateApplicationStatus(Request $request, Application $application): JsonResponse
-    {
-        $user = Auth::user();
-
-        if ($application->job->company->user_id !== $user->id) {
-            return $this->forbidden('You do not own the job for this application.');
-        }
-
-        $request->validate([
-            'status' => ['required', Rule::in([
-                ApplicationStatus::ACCEPTED->value,
-                ApplicationStatus::REJECTED->value,
-            ])],
-        ]);
-
-        $application->update(['status' => $request->status]);
-
-        // Notify the candidate
-        app(NotificationService::class)
-            ->notifyApplicationStatusChanged($application->load('job'));
-
-        return $this->success(
-            $application->fresh(['user:id,name', 'job:id,title']),
-            'Application status updated successfully'
-        );
     }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -56,7 +56,6 @@ Route::middleware('auth:sanctum')->group(function () {
     Route::middleware('role:employer')->group(function () {
         Route::get('/employer/analytics', [EmployerAnalyticsController::class, 'index']);
         Route::get('/employer/jobs/{job}/applications', [EmployerAnalyticsController::class, 'jobApplications']);
-        Route::patch('/employer/applications/{application}', [EmployerAnalyticsController::class, 'updateApplicationStatus']);
     });
 
     //  Admin

--- a/tests/Feature/Employer/EmployerAnalyticsTest.php
+++ b/tests/Feature/Employer/EmployerAnalyticsTest.php
@@ -1,6 +1,5 @@
 <?php
 
-use App\Enums\ApplicationStatus;
 use App\Enums\UserRole;
 use App\Models\Application;
 use App\Models\Company;
@@ -66,60 +65,4 @@ test('employer cannot view applications for another employer\'s job', function (
     $this->actingAs($employer)
         ->getJson("/api/employer/jobs/{$job->id}/applications")
         ->assertForbidden();
-});
-
-// ── Update Application Status ─────────────────────────────────────────────────
-
-test('employer can accept an application for their job', function () {
-    $employer = employerWithCompany();
-    $job = Job::factory()->create(['company_id' => $employer->company->id]);
-    $application = Application::factory()->create(['job_id' => $job->id]);
-
-    $this->actingAs($employer)
-        ->patchJson("/api/employer/applications/{$application->id}", [
-            'status' => ApplicationStatus::ACCEPTED->value,
-        ])
-        ->assertOk();
-
-    expect($application->fresh()->status)->toBe(ApplicationStatus::ACCEPTED);
-});
-
-test('accepting application sends notification to candidate', function () {
-    $employer = employerWithCompany();
-    $job = Job::factory()->create(['company_id' => $employer->company->id]);
-    $application = Application::factory()->create(['job_id' => $job->id]);
-
-    $this->actingAs($employer)->patchJson("/api/employer/applications/{$application->id}", [
-        'status' => ApplicationStatus::ACCEPTED->value,
-    ]);
-
-    $this->assertDatabaseHas('notifications', [
-        'user_id' => $application->user_id,
-        'type' => 'application_status_changed',
-    ]);
-});
-
-test('employer cannot update application for another employer\'s job', function () {
-    $employer1 = employerWithCompany();
-    $employer2 = employerWithCompany();
-    $job = Job::factory()->create(['company_id' => $employer2->company->id]);
-    $application = Application::factory()->create(['job_id' => $job->id]);
-
-    $this->actingAs($employer1)
-        ->patchJson("/api/employer/applications/{$application->id}", [
-            'status' => ApplicationStatus::ACCEPTED->value,
-        ])
-        ->assertForbidden();
-});
-
-test('status must be accepted or rejected', function () {
-    $employer = employerWithCompany();
-    $job = Job::factory()->create(['company_id' => $employer->company->id]);
-    $application = Application::factory()->create(['job_id' => $job->id]);
-
-    $this->actingAs($employer)
-        ->patchJson("/api/employer/applications/{$application->id}", [
-            'status' => 'pending', // not allowed via this endpoint
-        ])
-        ->assertUnprocessable();
 });


### PR DESCRIPTION
This pull request removes the ability for employers to update the status of job applications via the API. The corresponding controller method, route, and all related feature tests have been deleted, simplifying the employer analytics functionality and reducing code complexity.

**Removal of application status update functionality:**

* Deleted the `updateApplicationStatus` method from `EmployerAnalyticsController`, which previously allowed employers to accept or reject applications and notify candidates.
* Removed the associated route (`PATCH /employer/applications/{application}`) from `routes/api.php`.
* Deleted all feature tests related to updating application status, including tests for accepting/rejecting applications, notifications, authorization, and input validation, from `EmployerAnalyticsTest.php`.

**Code cleanup:**

* Removed unused imports from `EmployerAnalyticsController.php` and `EmployerAnalyticsTest.php`. [[1]](diffhunk://#diff-c9e106e8ad21f7c14891474277a3c8296b83bbc3d20be3b7ddce91fe45f0307dL9-L13) [[2]](diffhunk://#diff-43cb5dae43241689c583df057417028904bf7fe093a5a0f0011ef2e17ba641c3L3)

**Fixes #44**