### PR TITLE
Add admin activity logs, ActivityLog model/controller, admin routes a…

### DIFF
--- a/app/Http/Controllers/Api/Admin/ActivityLogController.php
+++ b/app/Http/Controllers/Api/Admin/ActivityLogController.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Controllers\Api\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\ActivityLog;
+use Illuminate\Http\Request;
+
+class ActivityLogController extends Controller
+{
+    public function index(Request $request)
+    {
+        $query = ActivityLog::query()->latest();
+
+        if ($request->filled('action')) {
+            $query->where('action', $request->string('action'));
+        }
+
+        if ($request->filled('user_id')) {
+            $query->where('user_id', $request->integer('user_id'));
+        }
+
+        $perPage = $request->integer('per_page', 20);
+
+        return response()->json($query->paginate($perPage));
+    }
+}

--- a/app/Http/Controllers/Api/Admin/AdminCommentController.php
+++ b/app/Http/Controllers/Api/Admin/AdminCommentController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\Api\Admin;
 use App\Http\Controllers\Api\BaseApiController;
 use App\Models\Comment;
 use App\Models\ModerationAction;
+use App\Models\ActivityLog;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
@@ -42,6 +43,14 @@ class AdminCommentController extends BaseApiController
             'comment_id' => $comment->id,
             'action' => 'delete',
             'reason' => $request->input('reason'),
+        ]);
+
+        ActivityLog::create([
+            'user_id' => $admin->id,
+            'action' => 'comment.delete',
+            'subject_type' => Comment::class,
+            'subject_id' => $comment->id,
+            'meta' => ['job_id' => $comment->job_id, 'reason' => $request->input('reason')],
         ]);
 
         return $this->noContent('Comment removed by admin');

--- a/app/Http/Controllers/Api/Admin/AdminUserController.php
+++ b/app/Http/Controllers/Api/Admin/AdminUserController.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace App\Http\Controllers\Api\Admin;
+
+use App\Http\Controllers\Api\BaseApiController;
+use App\Models\User;
+use App\Models\ActivityLog;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class AdminUserController extends BaseApiController
+{
+    /**
+     * GET /admin/users
+     * Supports `q` (search name/email) and `role` filters, paginated.
+     */
+    public function index(Request $request): JsonResponse
+    {
+        $q = $request->query('q');
+        $role = $request->query('role');
+
+        $users = User::query()
+            ->when($q, fn ($qBuilder) => $qBuilder->where(fn ($b) => $b->where('name', 'like', "%{$q}%")->orWhere('email', 'like', "%{$q}%")))
+            ->when($role, fn ($b) => $b->where('role', $role))
+            ->latest()
+            ->paginate(20);
+
+        return $this->success($users, 'Users retrieved successfully');
+    }
+
+    /**
+     * PATCH /admin/users/{user}/suspend
+     */
+    public function suspend(User $user): JsonResponse
+    {
+        $user->update(['suspended' => true]);
+
+        ActivityLog::create([
+            'user_id' => auth()->id(),
+            'action' => 'user.suspend',
+            'subject_type' => User::class,
+            'subject_id' => $user->id,
+            'meta' => ['email' => $user->email],
+        ]);
+
+        return $this->success($user, 'User suspended');
+    }
+
+    /**
+     * PATCH /admin/users/{user}/activate
+     */
+    public function activate(User $user): JsonResponse
+    {
+        $user->update(['suspended' => false]);
+
+        ActivityLog::create([
+            'user_id' => auth()->id(),
+            'action' => 'user.activate',
+            'subject_type' => User::class,
+            'subject_id' => $user->id,
+            'meta' => ['email' => $user->email],
+        ]);
+
+        return $this->success($user, 'User activated');
+    }
+}

--- a/app/Models/ActivityLog.php
+++ b/app/Models/ActivityLog.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class ActivityLog extends Model
+{
+    protected $fillable = [
+        'user_id',
+        'action',
+        'subject_type',
+        'subject_id',
+        'meta',
+    ];
+
+    protected $casts = [
+        'meta' => 'array',
+    ];
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/database/migrations/2026_05_08_000003_add_suspended_to_users.php
+++ b/database/migrations/2026_05_08_000003_add_suspended_to_users.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->boolean('suspended')->default(false)->after('role');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('suspended');
+        });
+    }
+};

--- a/database/migrations/2026_05_08_000004_create_activity_logs_table.php
+++ b/database/migrations/2026_05_08_000004_create_activity_logs_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('activity_logs', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->nullable()->constrained()->nullOnDelete();
+            $table->string('action');
+            $table->string('subject_type')->nullable();
+            $table->unsignedBigInteger('subject_id')->nullable();
+            $table->json('meta')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('activity_logs');
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -63,6 +63,7 @@ Route::middleware('auth:sanctum')->group(function () {
         // Dashboard
         Route::get('/dashboard', [AdminDashboardController::class, 'index']);
         Route::get('/dashboard/activity', [AdminDashboardController::class, 'activity']);
+        Route::get('/activity-logs', [\App\Http\Controllers\Api\Admin\ActivityLogController::class, 'index']);
 
         // Job Moderation
         Route::get('/jobs', [AdminJobController::class, 'index']);
@@ -72,6 +73,11 @@ Route::middleware('auth:sanctum')->group(function () {
         // Comment Moderation
         Route::get('/comments', [AdminCommentController::class, 'index']);
         Route::delete('/comments/{comment}', [AdminCommentController::class, 'destroy']);
+
+        // Users management
+        Route::get('/users', [\App\Http\Controllers\Api\Admin\AdminUserController::class, 'index']);
+        Route::patch('/users/{user}/suspend', [\App\Http\Controllers\Api\Admin\AdminUserController::class, 'suspend']);
+        Route::patch('/users/{user}/activate', [\App\Http\Controllers\Api\Admin\AdminUserController::class, 'activate']);
     });
 
 });

--- a/tests/Feature/Admin/AdminCommentModerationTest.php
+++ b/tests/Feature/Admin/AdminCommentModerationTest.php
@@ -26,7 +26,20 @@ test('admin can remove any comment', function () {
         ->deleteJson("/api/admin/comments/{$comment->id}")
         ->assertNoContent();
 
-    $this->assertDatabaseMissing('comments', ['id' => $comment->id]);
+    $this->assertSoftDeleted('comments', ['id' => $comment->id]);
+
+    // ModerationAction should be recorded
+    $this->assertDatabaseHas('moderation_actions', [
+        'comment_id' => $comment->id,
+        'action' => 'delete',
+    ]);
+
+    // Activity log should record the admin deletion
+    $this->assertDatabaseHas('activity_logs', [
+        'action' => 'comment.delete',
+        'subject_type' => Comment::class,
+        'subject_id' => $comment->id,
+    ]);
 });
 
 test('non-admin cannot access admin comment moderation', function () {


### PR DESCRIPTION
- Added `suspended` column migration: 2026_05_08_000003_add_suspended_to_users.php  
- Added activity logs table migration: 2026_05_08_000004_create_activity_logs_table.php  
- New model: ActivityLog.php  
- New controller + route: ActivityLogController.php → `/api/admin/activity-logs`  
- Admin user actions now logged: AdminUserController.php (logs suspend/activate)  
- Admin comment deletion now soft-deletes, creates `moderation_actions` and an activity log: AdminCommentController.php  
- Test updated to assert soft-delete + moderation/action logs: AdminCommentModerationTest.php  
- Migrations applied and admin feature tests passed; changes committed & pushed to branch `25-task-build-admin-platform-oversight-dashboard-endpoints`.