### PR TITLE
Admin job moderation: switch approve/reject to PATCH, add bulk approv…

### DIFF
--- a/app/Http/Controllers/Api/Admin/AdminJobController.php
+++ b/app/Http/Controllers/Api/Admin/AdminJobController.php
@@ -41,6 +41,12 @@ class AdminJobController extends BaseApiController
 
         $job->update(['status' => JobStatus::APPROVED]);
 
+        // Clear any previous rejection reason when approving
+        if (isset($job->rejection_reason)) {
+            $job->rejection_reason = null;
+            $job->save();
+        }
+
         // Notify the employer
         $job->company->user->notifications()->create([
             'type' => 'job_approved',
@@ -71,7 +77,7 @@ class AdminJobController extends BaseApiController
             );
         }
 
-        $job->update(['status' => JobStatus::REJECTED]);
+        $job->update(['status' => JobStatus::REJECTED, 'rejection_reason' => $request->reason]);
 
         // Notify the employer with the rejection reason
         $job->company->user->notifications()->create([
@@ -84,5 +90,61 @@ class AdminJobController extends BaseApiController
             $job->fresh(['company']),
             'Job rejected successfully'
         );
+    }
+
+    /**
+     * Bulk approve jobs by ids.
+     * POST /admin/jobs/bulk-approve
+     */
+    public function bulkApprove(Request $request): JsonResponse
+    {
+        $request->validate([
+            'ids' => ['required', 'array'],
+            'ids.*' => ['integer', 'exists:jobs,id'],
+        ]);
+
+        $ids = $request->input('ids');
+
+        $jobs = Job::whereIn('id', $ids)->where('status', JobStatus::PENDING)->get();
+
+        foreach ($jobs as $job) {
+            $job->update(['status' => JobStatus::APPROVED, 'rejection_reason' => null]);
+            $job->company->user->notifications()->create([
+                'type' => 'job_approved',
+                'message' => "Your job posting \"{$job->title}\" has been approved and is now live.",
+                'is_read' => false,
+            ]);
+        }
+
+        return $this->success(['count' => $jobs->count()], 'Bulk approve completed');
+    }
+
+    /**
+     * Bulk reject jobs by ids with a reason.
+     * POST /admin/jobs/bulk-reject
+     */
+    public function bulkReject(Request $request): JsonResponse
+    {
+        $request->validate([
+            'ids' => ['required', 'array'],
+            'ids.*' => ['integer', 'exists:jobs,id'],
+            'reason' => ['required', 'string', 'max:1000'],
+        ]);
+
+        $ids = $request->input('ids');
+        $reason = $request->input('reason');
+
+        $jobs = Job::whereIn('id', $ids)->where('status', JobStatus::PENDING)->get();
+
+        foreach ($jobs as $job) {
+            $job->update(['status' => JobStatus::REJECTED, 'rejection_reason' => $reason]);
+            $job->company->user->notifications()->create([
+                'type' => 'job_rejected',
+                'message' => "Your job posting \"{$job->title}\" was rejected. Reason: {$reason}",
+                'is_read' => false,
+            ]);
+        }
+
+        return $this->success(['count' => $jobs->count()], 'Bulk reject completed');
     }
 }

--- a/app/Models/Job.php
+++ b/app/Models/Job.php
@@ -32,6 +32,7 @@ class Job extends Model
         'experience_level',
         'deadline',
         'status',
+        'rejection_reason',
     ];
 
     protected function casts(): array

--- a/database/migrations/2026_05_08_000005_add_rejection_reason_to_jobs.php
+++ b/database/migrations/2026_05_08_000005_add_rejection_reason_to_jobs.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('job_listings', function (Blueprint $table) {
+            $table->text('rejection_reason')->nullable()->after('status');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('job_listings', function (Blueprint $table) {
+            $table->dropColumn('rejection_reason');
+        });
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -67,8 +67,11 @@ Route::middleware('auth:sanctum')->group(function () {
 
         // Job Moderation
         Route::get('/jobs', [AdminJobController::class, 'index']);
-        Route::post('/jobs/{job}/approve', [AdminJobController::class, 'approve']);
-        Route::post('/jobs/{job}/reject', [AdminJobController::class, 'reject']);
+        Route::patch('/jobs/{job}/approve', [AdminJobController::class, 'approve']);
+        Route::patch('/jobs/{job}/reject', [AdminJobController::class, 'reject']);
+        // Bulk moderation (optional)
+        Route::post('/jobs/bulk-approve', [AdminJobController::class, 'bulkApprove']);
+        Route::post('/jobs/bulk-reject', [AdminJobController::class, 'bulkReject']);
 
         // Comment Moderation
         Route::get('/comments', [AdminCommentController::class, 'index']);

--- a/tests/Feature/Admin/AdminJobModerationTest.php
+++ b/tests/Feature/Admin/AdminJobModerationTest.php
@@ -47,7 +47,7 @@ test('admin can approve a pending job', function () {
     $job = pendingJob();
 
     $this->actingAs($admin)
-        ->postJson("/api/admin/jobs/{$job->id}/approve")
+        ->patchJson("/api/admin/jobs/{$job->id}/approve")
         ->assertOk()
         ->assertJsonPath('success', true);
 
@@ -59,7 +59,7 @@ test('admin cannot approve an already-approved job', function () {
     $job = Job::factory()->approved()->create();
 
     $this->actingAs($admin)
-        ->postJson("/api/admin/jobs/{$job->id}/approve")
+        ->patchJson("/api/admin/jobs/{$job->id}/approve")
         ->assertUnprocessable();
 });
 
@@ -67,7 +67,7 @@ test('approving a job notifies the employer', function () {
     $admin = adminUser();
     $job = pendingJob();
 
-    $this->actingAs($admin)->postJson("/api/admin/jobs/{$job->id}/approve");
+    $this->actingAs($admin)->patchJson("/api/admin/jobs/{$job->id}/approve");
 
     $this->assertDatabaseHas('notifications', [
         'user_id' => $job->company->user_id,
@@ -82,7 +82,7 @@ test('admin can reject a pending job with a reason', function () {
     $job = pendingJob();
 
     $this->actingAs($admin)
-        ->postJson("/api/admin/jobs/{$job->id}/reject", ['reason' => 'Violates guidelines.'])
+        ->patchJson("/api/admin/jobs/{$job->id}/reject", ['reason' => 'Violates guidelines.'])
         ->assertOk()
         ->assertJsonPath('success', true);
 
@@ -94,7 +94,7 @@ test('rejection requires a reason', function () {
     $job = pendingJob();
 
     $this->actingAs($admin)
-        ->postJson("/api/admin/jobs/{$job->id}/reject", [])
+        ->patchJson("/api/admin/jobs/{$job->id}/reject", [])
         ->assertUnprocessable();
 });
 
@@ -102,7 +102,7 @@ test('rejecting a job notifies the employer', function () {
     $admin = adminUser();
     $job = pendingJob();
 
-    $this->actingAs($admin)->postJson("/api/admin/jobs/{$job->id}/reject", ['reason' => 'Spam.']);
+    $this->actingAs($admin)->patchJson("/api/admin/jobs/{$job->id}/reject", ['reason' => 'Spam.']);
 
     $this->assertDatabaseHas('notifications', [
         'user_id' => $job->company->user_id,


### PR DESCRIPTION
What I changed (simple lines):

- Switched single approve/reject routes to PATCH /api/admin/jobs/{id}/approve and PATCH /api/admin/jobs/{id}/reject. (Updated [api.php](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html).)
- Added bulk endpoints: POST /api/admin/jobs/bulk-approve and POST /api/admin/jobs/bulk-reject. (Updated [api.php](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html).)
- Persisted rejection feedback: added rejection_reason column to job_listings via migration [2026_05_08_000005_add_rejection_reason_to_jobs.php](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html).
- Allowed rejection_reason on Job model ([Job.php](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)).
- Updated AdminJobController to:
   - Save/clear rejection_reason on reject/approve.
   - Add bulkApprove() and bulkReject() to handle bulk moderation and notify employers.
- Updated tests to call PATCH for approve/reject: [AdminJobModerationTest.php](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html).
- Ran migrations and admin tests — all admin tests passed.